### PR TITLE
#1547: Add CVE-2020-7921 to allowed list of vulnerabilities for Anchor CLI docker image scans

### DIFF
--- a/container-scanning/mojaloop-policy-generator.js
+++ b/container-scanning/mojaloop-policy-generator.js
@@ -467,6 +467,11 @@ const policy = {
           gate: 'vulnerabilities',
           trigger_id: 'CVE-2016-6494+*',
         },
+        {
+          id: 'rule10',
+          gate: 'vulnerabilities',
+          trigger_id: 'CVE-2020-7921+*',
+        },
       ]
     }
   ]


### PR DESCRIPTION
Added [CVE-2020-7921](https://nvd.nist.gov/vuln/detail/CVE-2020-7921)  to allowed list of vulnerabilities as it is false negative for mongodb nodejs driver used in mongoose. 

The vulnerability affects certain versions ( 4.2 versions prior to 4.2.3; 4.0 versions prior to 4.0.15; 4.3 versions prior to 4.3.3; 3.6 versions prior to 3.6.18) of mongodb _server_ but not [mongodb _driver_ for nodejs](https://www.npmjs.com/package/mongodb) which bears the same name (i.e "mongodb") as the server in the `package.json` file in mongoose.