### PR TITLE
chore: whitelist cookie vulnerability in express

### DIFF
--- a/container-scanning/mojaloop-policy-generator.js
+++ b/container-scanning/mojaloop-policy-generator.js
@@ -472,6 +472,12 @@ const policy = {
           gate: 'vulnerabilities',
           trigger_id: 'CVE-2020-7921+*',
         },
+        // Whitelist for cookie dependency in express https://github.com/anchore/anchore-engine/issues/304
+        {
+          id: 'rule11',
+          gate: 'vulnerabilities',
+          trigger_id: 'CVE-2017-18589+*',
+        },
       ]
     }
   ]


### PR DESCRIPTION
Unsure why this vulnerability is only popping up now.
Not sure if this is the right thing to do, please advise.

```
    [
      "b7cd165aa211d9c0ee2c1568cabc4f5ae31f4a62e000a9ba86117d923795107c",
      "localhost:5000/central-ledger:v11.3.3.0-pisp",
      "CVE-2017-18589+cookie",
      "vulnerabilities",
      "package",
      "HIGH Vulnerability found in non-os package type (npm) - /opt/central-ledger/node_modules/express/node_modules/cookie/package.json (CVE-2017-18589 - https://nvd.nist.gov/vuln/detail/CVE-2017-18589)",
      "stop",
      false,
      "cis_software_checks"
    ],
 ```