### PR TITLE
fix: pr title check broken for forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This example adds a `pr-title-check` step in the build's jobs. If the build is n
 version: 2.1
 
 orbs:
-  pr-tools: mojaloop/pr-tools@0.1.8
+  pr-tools: mojaloop/pr-tools@0.1.9
 
 workflows:
   version: 2.1

--- a/pr-tools/_pr_title.js
+++ b/pr-tools/_pr_title.js
@@ -6,13 +6,7 @@ const format = require('@commitlint/format').default
 const conventional = require('@commitlint/config-conventional')
 const Logger = require('@mojaloop/central-services-logger')
 
-if (!process.env.GITHUB_TOKEN) {
-  throw new Error('Github token is required')
-}
-
-const octokit = new Octokit({
-  auth: process.env.GITHUB_TOKEN
-})
+const octokit = new Octokit({})
 
 if (!process.env.CIRCLE_PULL_REQUEST && !process.env.CIRCLE_PULL_REQUESTS) {
   Logger.info('No `CIRCLE_PULL_REQUEST` or `CIRCLE_PULL_REQUESTS` variable found')

--- a/pr-tools/package.json
+++ b/pr-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/ci-config",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "repository": "https://github.com/mojaloop/ci-config",
   "author": "Lewis Daly <lewisd@crosslaketech.com>",
   "license": "Apache 2.0",


### PR DESCRIPTION
The PR title check was failing silently since forks don't get the `GITHUB_TOKEN` injected. Luckily PRs are public and don't require auth with github's api.