### PR TITLE
fix:  update broken doc link in error message for pr-tools

### DIFF
--- a/pr-tools/src/config.js
+++ b/pr-tools/src/config.js
@@ -17,7 +17,7 @@ const ConvictConfig = Convict({
   GET_HELP_URL: {
     doc: 'The url to a help document',
     format: String,
-    default: 'https://docs.mojaloop.io/documentation/contributors-guide/standards/creating-new-features.html',
+    default: 'https://docs.mojaloop.io/community/standards/creating-new-features.html',
     env: 'GET_HELP_URL'
   }
 })


### PR DESCRIPTION
When the title check fails using pr-tools in circle-ci the error message uses a broken mojaloop doc link, this fix updates to point to the correct page at https://docs.mojaloop.io/community/standards/creating-new-features.html