### PR TITLE
chore: adding new alpine image to config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,9 @@ jobs:
           command: |
             docker pull node:12.16.0-alpine
             docker pull node:12.16.1-alpine
+            docker pull node:18-alpine3.19
       - anchore/analyze_local_image:
-          image_name: docker.io/node:12.16.0-alpine docker.io/node:12.16.1-alpine
+          image_name: docker.io/node:12.16.0-alpine docker.io/node:12.16.1-alpine docker.io/node:18-alpine3.19
           # TODO: is this even respecting this bundle? - maybe this can't be an absolute path
           policy_bundle_file_path: .circleci/.anchore/policy_bundle.json
           policy_failure: false

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,38 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+## These owners will be the default owners for everything in
+## the repo. Unless a later match takes precedence,
+## @global-owner1 and @global-owner2 will be requested for
+## review when someone opens a pull request.
+#*       @global-owner1 @global-owner2
+*   @elnyry-sam-k @oderayi @vijayg10 @bushjames @kleyow @geka-evk
+
+## Order is important; the last matching pattern takes the most
+## precedence. When someone opens a pull request that only
+## modifies JS files, only @js-owner and not the global
+## owner(s) will be requested for a review.
+# *.js    @js-owner
+
+## You can also use email addresses if you prefer. They'll be
+## used to look up users just like we do for commit author
+## emails.
+#*.go docs@example.com
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+# /build/logs/ @doctocat
+
+## The `docs/*` pattern will match files like
+## `docs/getting-started.md` but not further nested files like
+## `docs/build-app/troubleshooting.md`.
+# docs/*  docs@example.com
+
+## In this example, @octocat owns any file in an apps directory
+## anywhere in your repository.
+#apps/ @octocat
+
+## In this example, @doctocat owns any file in the `/docs`
+## directory in the root of your repository.
+#/docs/ @doctocat

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # LICENSE
 
-Copyright © 2020 Mojaloop Foundation
+Copyright © 2020-2024 Mojaloop Foundation
 
 The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0
 (the "License") and you may not use these files except in compliance with the [License](http://www.apache.org/licenses/LICENSE-2.0). 


### PR DESCRIPTION
Only two images are currently supported alpine node 12.

This change adds a newer image `node:18-alpine3.19`